### PR TITLE
Implement missing and fix broken PPU instructions in the interpreter.

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -1675,6 +1675,10 @@ private:
 	{
 		DisAsm_V1_R2("stvlx", vs, ra, rb);
 	}
+	void STDBRX(u32 rs, u32 ra, u32 rb)
+	{
+		DisAsm_R3("stdbrx", rs, ra, rb);
+	}
 	void STSWX(u32 rs, u32 ra, u32 rb)
 	{
 		DisAsm_R3("swswx", rs, ra, rb);

--- a/rpcs3/Emu/Cell/PPUInstrTable.h
+++ b/rpcs3/Emu/Cell/PPUInstrTable.h
@@ -226,6 +226,9 @@ namespace PPU_instr
 
 #define bind_instr(list, name, ...) \
 	static const auto& name = make_instr<PPU_opcodes::name>(list, #name, &PPUOpcodes::name, ##__VA_ARGS__)
+#define bind_instr_oe(list, name, ...) \
+	bind_instr(list, name, ##__VA_ARGS__); \
+	static const auto& name##O = make_instr<PPU_opcodes::name##O>(list, #name "O", &PPUOpcodes::name, ##__VA_ARGS__)
 
 		bind_instr(main_list, TDI, TO, RA, simm16);
 		bind_instr(main_list, TWI, TO, RA, simm16);
@@ -456,9 +459,9 @@ namespace PPU_instr
 		/*0x004*/bind_instr(g1f_list, TW, TO, RA, RB);
 		/*0x006*/bind_instr(g1f_list, LVSL, VD, RA, RB);
 		/*0x007*/bind_instr(g1f_list, LVEBX, VD, RA, RB);
-		/*0x008*/bind_instr(g1f_list, SUBFC, RD, RA, RB, OE, RC);
+		/*0x008*/bind_instr_oe(g1f_list, SUBFC, RD, RA, RB, OE, RC);
 		/*0x009*/bind_instr(g1f_list, MULHDU, RD, RA, RB, RC);
-		/*0x00a*/bind_instr(g1f_list, ADDC, RD, RA, RB, OE, RC);
+		/*0x00a*/bind_instr_oe(g1f_list, ADDC, RD, RA, RB, OE, RC);
 		/*0x00b*/bind_instr(g1f_list, MULHWU, RD, RA, RB, RC);
 		/*0x013*/bind_instr(g1f_list, MFOCRF, L_11, RD, CRM);
 		/*0x014*/bind_instr(g1f_list, LWARX, RD, RA, RB);
@@ -471,7 +474,7 @@ namespace PPU_instr
 		/*0x020*/bind_instr(g1f_list, CMPL, CRFD, L_10, RA, RB);
 		/*0x026*/bind_instr(g1f_list, LVSR, VD, RA, RB);
 		/*0x027*/bind_instr(g1f_list, LVEHX, VD, RA, RB);
-		/*0x028*/bind_instr(g1f_list, SUBF, RD, RA, RB, OE, RC);
+		/*0x028*/bind_instr_oe(g1f_list, SUBF, RD, RA, RB, OE, RC);
 		/*0x035*/bind_instr(g1f_list, LDUX, RD, RA, RB);
 		/*0x036*/bind_instr(g1f_list, DCBST, RA, RB);
 		/*0x037*/bind_instr(g1f_list, LWZUX, RD, RA, RB);
@@ -485,12 +488,12 @@ namespace PPU_instr
 		/*0x056*/bind_instr(g1f_list, DCBF, RA, RB);
 		/*0x057*/bind_instr(g1f_list, LBZX, RD, RA, RB);
 		/*0x067*/bind_instr(g1f_list, LVX, VD, RA, RB);
-		/*0x068*/bind_instr(g1f_list, NEG, RD, RA, OE, RC);
+		/*0x068*/bind_instr_oe(g1f_list, NEG, RD, RA, OE, RC);
 		/*0x077*/bind_instr(g1f_list, LBZUX, RD, RA, RB);
 		/*0x07c*/bind_instr(g1f_list, NOR, RA, RS, RB, RC);
 		/*0x087*/bind_instr(g1f_list, STVEBX, VS, RA, RB);
-		/*0x088*/bind_instr(g1f_list, SUBFE, RD, RA, RB, OE, RC);
-		/*0x08a*/bind_instr(g1f_list, ADDE, RD, RA, RB, OE, RC);
+		/*0x088*/bind_instr_oe(g1f_list, SUBFE, RD, RA, RB, OE, RC);
+		/*0x08a*/bind_instr_oe(g1f_list, ADDE, RD, RA, RB, OE, RC);
 		/*0x090*/bind_instr(g1f_list, MTOCRF, L_11, CRM, RS);
 		/*0x095*/bind_instr(g1f_list, STDX, RS, RA, RB);
 		/*0x096*/bind_instr(g1f_list, STWCX_, RS, RA, RB);
@@ -499,18 +502,18 @@ namespace PPU_instr
 		/*0x0b5*/bind_instr(g1f_list, STDUX, RS, RA, RB);
 		/*0x0b7*/bind_instr(g1f_list, STWUX, RS, RA, RB);
 		/*0x0c7*/bind_instr(g1f_list, STVEWX, VS, RA, RB);
-		/*0x0c8*/bind_instr(g1f_list, SUBFZE, RD, RA, OE, RC);
-		/*0x0ca*/bind_instr(g1f_list, ADDZE, RD, RA, OE, RC);
+		/*0x0c8*/bind_instr_oe(g1f_list, SUBFZE, RD, RA, OE, RC);
+		/*0x0ca*/bind_instr_oe(g1f_list, ADDZE, RD, RA, OE, RC);
 		/*0x0d6*/bind_instr(g1f_list, STDCX_, RS, RA, RB);
 		/*0x0d7*/bind_instr(g1f_list, STBX, RS, RA, RB);
 		/*0x0e7*/bind_instr(g1f_list, STVX, VS, RA, RB);
-		/*0x0e8*/bind_instr(g1f_list, SUBFME, RD, RA, OE, RC);
-		/*0x0e9*/bind_instr(g1f_list, MULLD, RD, RA, RB, OE, RC);
-		/*0x0ea*/bind_instr(g1f_list, ADDME, RD, RA, OE, RC);
-		/*0x0eb*/bind_instr(g1f_list, MULLW, RD, RA, RB, OE, RC);
+		/*0x0e8*/bind_instr_oe(g1f_list, SUBFME, RD, RA, OE, RC);
+		/*0x0e9*/bind_instr_oe(g1f_list, MULLD, RD, RA, RB, OE, RC);
+		/*0x0ea*/bind_instr_oe(g1f_list, ADDME, RD, RA, OE, RC);
+		/*0x0eb*/bind_instr_oe(g1f_list, MULLW, RD, RA, RB, OE, RC);
 		/*0x0f6*/bind_instr(g1f_list, DCBTST, RA, RB, TH);
 		/*0x0f7*/bind_instr(g1f_list, STBUX, RS, RA, RB);
-		/*0x10a*/bind_instr(g1f_list, ADD, RD, RA, RB, OE, RC);
+		/*0x10a*/bind_instr_oe(g1f_list, ADD, RD, RA, RB, OE, RC);
 		/*0x116*/bind_instr(g1f_list, DCBT, RA, RB, TH);
 		/*0x117*/bind_instr(g1f_list, LHZX, RD, RA, RB);
 		/*0x11c*/bind_instr(g1f_list, EQV, RA, RS, RB, RC);
@@ -531,15 +534,21 @@ namespace PPU_instr
 		/*0x1b6*/bind_instr(g1f_list, ECOWX, RS, RA, RB);
 		/*0x1b7*/bind_instr(g1f_list, STHUX, RS, RA, RB);
 		/*0x1bc*/bind_instr(g1f_list, OR, RA, RS, RB, RC);
-		/*0x1c9*/bind_instr(g1f_list, DIVDU, RD, RA, RB, OE, RC);
-		/*0x1cb*/bind_instr(g1f_list, DIVWU, RD, RA, RB, OE, RC);
+		/*0x1c9*/bind_instr_oe(g1f_list, DIVDU, RD, RA, RB, OE, RC);
+		/*0x1cb*/bind_instr_oe(g1f_list, DIVWU, RD, RA, RB, OE, RC);
 		/*0x1d3*/bind_instr(g1f_list, MTSPR, SPR, RS);
 		/*0x1d6*///DCBI
 		/*0x1dc*/bind_instr(g1f_list, NAND, RA, RS, RB, RC);
 		/*0x1e7*/bind_instr(g1f_list, STVXL, VS, RA, RB);
-		/*0x1e9*/bind_instr(g1f_list, DIVD, RD, RA, RB, OE, RC);
-		/*0x1eb*/bind_instr(g1f_list, DIVW, RD, RA, RB, OE, RC);
+		/*0x1e9*/bind_instr_oe(g1f_list, DIVD, RD, RA, RB, OE, RC);
+		/*0x1eb*/bind_instr_oe(g1f_list, DIVW, RD, RA, RB, OE, RC);
 		/*0x207*/bind_instr(g1f_list, LVLX, VD, RA, RB);
+		// MULH{D|DU|W|WU} don't use OE, but a real Cell accepts
+		// opcodes with OE=1 and Rc=0, behaving as if OE was not set.
+		// OE=1 and Rc=1 causes an invalid instruction exception, but
+		// we don't worry about that.
+		static const auto& MULHDUO = make_instr<0x209>(g1f_list, "MULHDUO", &PPUOpcodes::MULHDU, RD, RA, RB, RC);
+		static const auto& MULHWUO = make_instr<0x20b>(g1f_list, "MULHWUO", &PPUOpcodes::MULHWU, RD, RA, RB, RC);
 		/*0x214*/bind_instr(g1f_list, LDBRX, RD, RA, RB);
 		/*0x215*/bind_instr(g1f_list, LSWX, RD, RA, RB);
 		/*0x216*/bind_instr(g1f_list, LWBRX, RD, RA, RB);
@@ -548,11 +557,14 @@ namespace PPU_instr
 		/*0x21b*/bind_instr(g1f_list, SRD, RA, RS, RB, RC);
 		/*0x227*/bind_instr(g1f_list, LVRX, VD, RA, RB);
 		/*0x237*/bind_instr(g1f_list, LFSUX, FRD, RA, RB);
+		static const auto& MULHDO = make_instr<0x249>(g1f_list, "MULHDO", &PPUOpcodes::MULHD, RD, RA, RB, RC);
+		static const auto& MULHWO = make_instr<0x24b>(g1f_list, "MULHWO", &PPUOpcodes::MULHW, RD, RA, RB, RC);
 		/*0x255*/bind_instr(g1f_list, LSWI, RD, RA, NB);
 		/*0x256*/bind_instr(g1f_list, SYNC, L_9_10);
 		/*0x257*/bind_instr(g1f_list, LFDX, FRD, RA, RB);
 		/*0x277*/bind_instr(g1f_list, LFDUX, FRD, RA, RB);
 		/*0x287*/bind_instr(g1f_list, STVLX, VS, RA, RB);
+		/*0x294*/bind_instr(g1f_list, STDBRX, RD, RA, RB);
 		/*0x296*/bind_instr(g1f_list, STSWX, RS, RA, RB);
 		/*0x296*/bind_instr(g1f_list, STWBRX, RS, RA, RB);
 		/*0x297*/bind_instr(g1f_list, STFSX, FRS, RA, RB);

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3746,22 +3746,16 @@ private:
 			switch(rn)
 			{
 			case FPSCR_RN_NEAR:
-				{
-					double t = b + 0.5;
-					i = (s32)t;
-					if (t - i < 0 || (t - i == 0 && b > 0)) i--;
-					break;
-				}
+				i = (s32)nearbyint(b);
+				break;
 			case FPSCR_RN_ZERO:
 				i = (s32)b;
 				break;
 			case FPSCR_RN_PINF:
-				i = (s32)b;
-				if (b - i > 0) i++;
+				i = (s32)ceil(b);
 				break;
 			case FPSCR_RN_MINF:
-				i = (s32)b;
-				if (b - i < 0) i--;
+				i = (s32)floor(b);
 				break;
 			}
 			r = (u32)i;
@@ -3977,22 +3971,16 @@ private:
 			switch(rn)
 			{
 			case FPSCR_RN_NEAR:
-				{
-					double t = b + 0.5;
-					i = (s64)t;
-					if (t - i < 0 || (t - i == 0 && b > 0)) i--;
-					break;
-				}
+				i = (s64)nearbyint(b);
+				break;
 			case FPSCR_RN_ZERO:
 				i = (s64)b;
 				break;
 			case FPSCR_RN_PINF:
-				i = (s64)b;
-				if (b - i > 0) i++;
+				i = (s64)ceil(b);
 				break;
 			case FPSCR_RN_MINF:
-				i = (s64)b;
-				if (b - i < 0) i--;
+				i = (s64)floor(b);
 				break;
 			}
 			r = (u64)i;

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -865,7 +865,7 @@ private:
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
 			{
-				CPU.VPR[vd]._f[w] = a * c + b;
+				CPU.VPR[vd]._f[w] = fmaf(a, c, b);
 				if (std::isnan(CPU.VPR[vd]._f[w]))
 					CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			}
@@ -1288,7 +1288,7 @@ private:
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
 			{
-				CPU.VPR[vd]._f[w] = -(a * c - b);
+				CPU.VPR[vd]._f[w] = -fmaf(a, c, -b);
 				if (std::isnan(CPU.VPR[vd]._f[w]))
 					CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			}

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3895,7 +3895,7 @@ private:
 		const double a = CPU.FPR[fra];
 		const double b = CPU.FPR[frb];
 		const double c = CPU.FPR[frc];
-		const double res = a * c + (sub ? -b : b);
+		const double res = fma(a, c, sub ? -b : b);
 		if(single) CPU.FPR[frd] = (float)(neg ? -res : res);
 		else       CPU.FPR[frd] = (neg ? -res : res);
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3795,7 +3795,10 @@ private:
 		const double r = static_cast<float>(b0);
 		CPU.FPSCR.FR = fabs(r) > fabs(b);
 		CPU.SetFPSCR_FI(b != r);
-		CPU.FPSCR.FPRF = PPCdouble(r).GetType();
+		u32 type = PPCdouble(r).GetType();
+		if (type == FPR_PN && r < ldexp(1.0, -126)) type = FPR_PD;
+		else if (type == FPR_NN && r > ldexp(-1.0, -126)) type = FPR_ND;
+		CPU.FPSCR.FPRF = type;
 		CPU.FPR[frd] = r;
 	}
 	void FCTIW(u32 frd, u32 frb, bool rc)

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -448,22 +448,7 @@ private:
 			CPU.VPR[vd]._f[w] = ((float)CPU.VPR[vb]._u32[w]) / scale;
 		}
 	}
-	void VCMPBFP(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			u32 mask = 0;
-
-			const float A = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
-			const float B = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
-
-			if (A >  B) mask |= 1 << 31;
-			if (A < -B) mask |= 1 << 30;
-
-			CPU.VPR[vd]._u32[w] = mask;
-		}
-	}
-	void VCMPBFP_(u32 vd, u32 va, u32 vb)
+	void VCMPBFP(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		bool allInBounds = true;
 
@@ -483,18 +468,16 @@ private:
 				allInBounds = false;
 		}
 
-		// Bit n°2 of CR6
-		CPU.SetCR(6, 0);
-		CPU.SetCRBit(6, 0x2, allInBounds);
-	}
-	void VCMPEQFP(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
+		if (rc)
 		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._f[w] == CPU.VPR[vb]._f[w] ? 0xffffffff : 0;
+			// Bit n°2 of CR6
+			CPU.SetCR(6, 0);
+			CPU.SetCRBit(6, 0x2, allInBounds);
 		}
 	}
-	void VCMPEQFP_(u32 vd, u32 va, u32 vb)
+	void VCMPBFP(u32 vd, u32 va, u32 vb) {VCMPBFP(vd, va, vb, false);}
+	void VCMPBFP_(u32 vd, u32 va, u32 vb) {VCMPBFP(vd, va, vb, true);}
+	void VCMPEQFP(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_equal = 0x8;
 		int none_equal = 0x2;
@@ -513,16 +496,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_equal | none_equal;
+		if (rc) CPU.CR.cr6 = all_equal | none_equal;
 	}
-	void VCMPEQUB(u32 vd, u32 va, u32 vb)
-	{
-		for (uint b = 0; b < 16; b++)
-		{
-			CPU.VPR[vd]._u8[b] = CPU.VPR[va]._u8[b] == CPU.VPR[vb]._u8[b] ? 0xff : 0;
-		}
-	}
-	void VCMPEQUB_(u32 vd, u32 va, u32 vb)
+	void VCMPEQFP(u32 vd, u32 va, u32 vb) {VCMPEQFP(vd, va, vb, false);}
+	void VCMPEQFP_(u32 vd, u32 va, u32 vb) {VCMPEQFP(vd, va, vb, true);}
+	void VCMPEQUB(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_equal = 0x8;
 		int none_equal = 0x2;
@@ -541,16 +519,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_equal | none_equal;
+		if (rc) CPU.CR.cr6 = all_equal | none_equal;
 	}
-	void VCMPEQUH(u32 vd, u32 va, u32 vb) //nf
-	{
-		for (uint h = 0; h < 8; h++)
-		{
-			CPU.VPR[vd]._u16[h] = CPU.VPR[va]._u16[h] == CPU.VPR[vb]._u16[h] ? 0xffff : 0;
-		}
-	}
-	void VCMPEQUH_(u32 vd, u32 va, u32 vb) //nf
+	void VCMPEQUB(u32 vd, u32 va, u32 vb) {VCMPEQUB(vd, va, vb, false);}
+	void VCMPEQUB_(u32 vd, u32 va, u32 vb) {VCMPEQUB(vd, va, vb, true);}
+	void VCMPEQUH(u32 vd, u32 va, u32 vb, bool rc) //nf
 	{
 		int all_equal = 0x8;
 		int none_equal = 0x2;
@@ -569,16 +542,11 @@ private:
 			}
 		}
 			
-		CPU.CR.cr6 = all_equal | none_equal;
+		if (rc) CPU.CR.cr6 = all_equal | none_equal;
 	}
-	void VCMPEQUW(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._u32[w] == CPU.VPR[vb]._u32[w] ? 0xffffffff : 0;
-		}
-	}
-	void VCMPEQUW_(u32 vd, u32 va, u32 vb)
+	void VCMPEQUH(u32 vd, u32 va, u32 vb) {VCMPEQUH(vd, va, vb, false);}
+	void VCMPEQUH_(u32 vd, u32 va, u32 vb) {VCMPEQUH(vd, va, vb, true);}
+	void VCMPEQUW(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_equal = 0x8;
 		int none_equal = 0x2;
@@ -597,16 +565,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_equal | none_equal;
+		if (rc) CPU.CR.cr6 = all_equal | none_equal;
 	}
-	void VCMPGEFP(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._f[w] >= CPU.VPR[vb]._f[w] ? 0xffffffff : 0;
-		}
-	}
-	void VCMPGEFP_(u32 vd, u32 va, u32 vb)
+	void VCMPEQUW(u32 vd, u32 va, u32 vb) {VCMPEQUW(vd, va, vb, false);}
+	void VCMPEQUW_(u32 vd, u32 va, u32 vb) {VCMPEQUW(vd, va, vb, true);}
+	void VCMPGEFP(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_ge = 0x8;
 		int none_ge = 0x2;
@@ -625,16 +588,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_ge | none_ge;
+		if (rc) CPU.CR.cr6 = all_ge | none_ge;
 	}
-	void VCMPGTFP(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._f[w] > CPU.VPR[vb]._f[w] ? 0xffffffff : 0;
-		}
-	}
-	void VCMPGTFP_(u32 vd, u32 va, u32 vb)
+	void VCMPGEFP(u32 vd, u32 va, u32 vb) {VCMPGEFP(vd, va, vb, false);}
+	void VCMPGEFP_(u32 vd, u32 va, u32 vb) {VCMPGEFP(vd, va, vb, true);}
+	void VCMPGTFP(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_ge = 0x8;
 		int none_ge = 0x2;
@@ -653,16 +611,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_ge | none_ge;
+		if (rc) CPU.CR.cr6 = all_ge | none_ge;
 	}
-	void VCMPGTSB(u32 vd, u32 va, u32 vb) //nf
-	{
-		for (uint b = 0; b < 16; b++)
-		{
-			CPU.VPR[vd]._u8[b] = CPU.VPR[va]._s8[b] > CPU.VPR[vb]._s8[b] ? 0xff : 0;
-		}
-	}
-	void VCMPGTSB_(u32 vd, u32 va, u32 vb)
+	void VCMPGTFP(u32 vd, u32 va, u32 vb) {VCMPGTFP(vd, va, vb, false);}
+	void VCMPGTFP_(u32 vd, u32 va, u32 vb) {VCMPGTFP(vd, va, vb, true);}
+	void VCMPGTSB(u32 vd, u32 va, u32 vb, bool rc) //nf
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -681,16 +634,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
-	void VCMPGTSH(u32 vd, u32 va, u32 vb)
-	{
-		for (uint h = 0; h < 8; h++)
-		{
-			CPU.VPR[vd]._u16[h] = CPU.VPR[va]._s16[h] > CPU.VPR[vb]._s16[h] ? 0xffff : 0;
-		}
-	}
-	void VCMPGTSH_(u32 vd, u32 va, u32 vb)
+	void VCMPGTSB(u32 vd, u32 va, u32 vb) {VCMPGTSB(vd, va, vb, false);}
+	void VCMPGTSB_(u32 vd, u32 va, u32 vb) {VCMPGTSB(vd, va, vb, true);}
+	void VCMPGTSH(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -709,16 +657,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
-	void VCMPGTSW(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._s32[w] > CPU.VPR[vb]._s32[w] ? 0xffffffff : 0;
-		}
-	}
-	void VCMPGTSW_(u32 vd, u32 va, u32 vb)
+	void VCMPGTSH(u32 vd, u32 va, u32 vb) {VCMPGTSH(vd, va, vb, false);}
+	void VCMPGTSH_(u32 vd, u32 va, u32 vb) {VCMPGTSH(vd, va, vb, true);}
+	void VCMPGTSW(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -737,16 +680,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
-	void VCMPGTUB(u32 vd, u32 va, u32 vb)
-	{
-		for (uint b = 0; b < 16; b++)
-		{
-			CPU.VPR[vd]._u8[b] = CPU.VPR[va]._u8[b] > CPU.VPR[vb]._u8[b] ? 0xff : 0;
-		}
-	}
-	void VCMPGTUB_(u32 vd, u32 va, u32 vb)
+	void VCMPGTSW(u32 vd, u32 va, u32 vb) {VCMPGTSW(vd, va, vb, false);}
+	void VCMPGTSW_(u32 vd, u32 va, u32 vb) {VCMPGTSW(vd, va, vb, true);}
+	void VCMPGTUB(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -765,16 +703,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
-	void VCMPGTUH(u32 vd, u32 va, u32 vb)
-	{
-		for (uint h = 0; h < 8; h++)
-		{
-			CPU.VPR[vd]._u16[h] = CPU.VPR[va]._u16[h] > CPU.VPR[vb]._u16[h] ? 0xffff : 0;
-		}
-	}
-	void VCMPGTUH_(u32 vd, u32 va, u32 vb)
+	void VCMPGTUB(u32 vd, u32 va, u32 vb) {VCMPGTUB(vd, va, vb, false);}
+	void VCMPGTUB_(u32 vd, u32 va, u32 vb) {VCMPGTUB(vd, va, vb, true);}
+	void VCMPGTUH(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -793,16 +726,11 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
-	void VCMPGTUW(u32 vd, u32 va, u32 vb)
-	{
-		for (uint w = 0; w < 4; w++)
-		{
-			CPU.VPR[vd]._u32[w] = CPU.VPR[va]._u32[w] > CPU.VPR[vb]._u32[w] ? 0xffffffff : 0;
-		}
-	}
-	void VCMPGTUW_(u32 vd, u32 va, u32 vb)
+	void VCMPGTUH(u32 vd, u32 va, u32 vb) {VCMPGTUH(vd, va, vb, false);}
+	void VCMPGTUH_(u32 vd, u32 va, u32 vb) {VCMPGTUH(vd, va, vb, true);}
+	void VCMPGTUW(u32 vd, u32 va, u32 vb, bool rc)
 	{
 		int all_gt = 0x8;
 		int none_gt = 0x2;
@@ -821,8 +749,10 @@ private:
 			}
 		}
 
-		CPU.CR.cr6 = all_gt | none_gt;
+		if (rc) CPU.CR.cr6 = all_gt | none_gt;
 	}
+	void VCMPGTUW(u32 vd, u32 va, u32 vb) {VCMPGTUW(vd, va, vb, false);}
+	void VCMPGTUW_(u32 vd, u32 va, u32 vb) {VCMPGTUW(vd, va, vb, true);}
 	void VCTSXS(u32 vd, u32 uimm5, u32 vb)
 	{
 		u32 nScale = 1 << uimm5;

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -2243,7 +2243,7 @@ private:
 	}
 	void BCCTR(u32 bo, u32 bi, u32 bh, u32 lk)
 	{
-		if(bo & 0x10 || CPU.IsCR(bi) == (bo & 0x8))
+		if(bo & 0x10 || CPU.IsCR(bi) == ((bo & 0x8) != 0))
 		{
 			const u32 nextLR = CPU.PC + 4;
 			CPU.SetBranch(branchTarget(0, (u32)CPU.CTR), true);

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -2698,12 +2698,12 @@ private:
 		if (CPU.R_ADDR == addr)
 		{
 			CPU.SetCR_EQ(0, InterlockedCompareExchange(vm::get_ptr<volatile u32>(vm::cast(CPU.R_ADDR)), re32((u32)CPU.GPR[rs]), (u32)CPU.R_VALUE) == (u32)CPU.R_VALUE);
-			CPU.R_ADDR = 0;
 		}
 		else
 		{
 			CPU.SetCR_EQ(0, false);
 		}
+		CPU.R_ADDR = 0;
 	}
 	void STWX(u32 rs, u32 ra, u32 rb)
 	{
@@ -2757,12 +2757,12 @@ private:
 		if (CPU.R_ADDR == addr)
 		{
 			CPU.SetCR_EQ(0, InterlockedCompareExchange(vm::get_ptr<volatile u64>(vm::cast(CPU.R_ADDR)), re64(CPU.GPR[rs]), CPU.R_VALUE) == CPU.R_VALUE);
-			CPU.R_ADDR = 0;
 		}
 		else
 		{
 			CPU.SetCR_EQ(0, false);
 		}
+		CPU.R_ADDR = 0;
 	}
 	void STBX(u32 rs, u32 ra, u32 rb)
 	{

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3593,64 +3593,10 @@ private:
 		const u64 addr = ra ? CPU.GPR[ra] + ds : ds;
 		CPU.GPR[rd] = (s64)(s32)vm::read32(vm::cast(addr));
 	}
-	void FDIVS(u32 frd, u32 fra, u32 frb, bool rc)
-	{
-		if(FPRdouble::IsNaN(CPU.FPR[fra]))
-		{
-			CPU.FPR[frd] = CPU.FPR[fra];
-		}
-		else if(FPRdouble::IsNaN(CPU.FPR[frb]))
-		{
-			CPU.FPR[frd] = CPU.FPR[frb];
-		}
-		else
-		{
-			if(CPU.FPR[frb] == 0.0)
-			{
-				if(CPU.FPR[fra] == 0.0)
-				{
-					CPU.FPSCR.VXZDZ = true;
-					CPU.FPR[frd] = FPR_NAN;
-				}
-				else
-				{
-					CPU.FPR[frd] = (float)(CPU.FPR[fra] / CPU.FPR[frb]);
-				}
-
-				CPU.FPSCR.ZX = true;
-			}
-			else if(FPRdouble::IsINF(CPU.FPR[fra]) && FPRdouble::IsINF(CPU.FPR[frb]))
-			{
-				CPU.FPSCR.VXIDI = true;
-				CPU.FPR[frd] = FPR_NAN;
-			}
-			else
-			{
-				CPU.FPR[frd] = (float)(CPU.FPR[fra] / CPU.FPR[frb]);
-			}
-		}
-
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FSUBS(u32 frd, u32 fra, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(CPU.FPR[fra] - CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FADDS(u32 frd, u32 fra, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(CPU.FPR[fra] + CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FSQRTS(u32 frd, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(sqrt(CPU.FPR[frb]));
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
+	void FDIVS(u32 frd, u32 fra, u32 frb, bool rc) {FDIV(frd, fra, frb, rc, true);}
+	void FSUBS(u32 frd, u32 fra, u32 frb, bool rc) {FSUB(frd, fra, frb, rc, true);}
+	void FADDS(u32 frd, u32 fra, u32 frb, bool rc) {FADD(frd, fra, frb, rc, true);}
+	void FSQRTS(u32 frd, u32 frb, bool rc) {FSQRT(frd, frb, rc, true);}
 	void FRES(u32 frd, u32 frb, bool rc)
 	{
 		if(CPU.FPR[frb] == 0.0)
@@ -3660,38 +3606,11 @@ private:
 		CPU.FPR[frd] = static_cast<float>(1.0 / CPU.FPR[frb]);
 		if(rc) CPU.UpdateCR1();
 	}
-	void FMULS(u32 frd, u32 fra, u32 frc, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(CPU.FPR[fra] * CPU.FPR[frc]);
-		CPU.FPSCR.FI = 0;
-		CPU.FPSCR.FR = 0;
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FMADDS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(CPU.FPR[fra] * CPU.FPR[frc] + CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FMSUBS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(CPU.FPR[fra] * CPU.FPR[frc] - CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FNMSUBS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(-(CPU.FPR[fra] * CPU.FPR[frc] - CPU.FPR[frb]));
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FNMADDS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = static_cast<float>(-(CPU.FPR[fra] * CPU.FPR[frc] + CPU.FPR[frb]));
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
+	void FMULS(u32 frd, u32 fra, u32 frc, bool rc) {FMUL(frd, fra, frc, rc, true);}
+	void FMADDS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, false, false, true);}
+	void FMSUBS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, false, true, true);}
+	void FNMSUBS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, true, true, true);}
+	void FNMADDS(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, true, false, true);}
 	void STD(u32 rs, u32 ra, s32 d)
 	{
 		const u64 addr = ra ? CPU.GPR[ra] + d : d;
@@ -3801,7 +3720,8 @@ private:
 		CPU.FPSCR.FPRF = type;
 		CPU.FPR[frd] = r;
 	}
-	void FCTIW(u32 frd, u32 frb, bool rc)
+	void FCTIW(u32 frd, u32 frb, bool rc) {FCTIW(frd, frb, rc, false);}
+	void FCTIW(u32 frd, u32 frb, bool rc, bool truncate)
 	{
 		const double b = CPU.FPR[frb];
 		u32 r;
@@ -3822,7 +3742,8 @@ private:
 		else
 		{
 			s32 i = 0;
-			switch(CPU.FPSCR.RN)
+			const u32 rn = truncate ? FPSCR_RN_ZERO : CPU.FPSCR.RN;
+			switch(rn)
 			{
 			case FPSCR_RN_NEAR:
 				{
@@ -3860,45 +3781,9 @@ private:
 		(u64&)CPU.FPR[frd] = r;
 		if(rc) CPU.UpdateCR1();
 	}
-	void FCTIWZ(u32 frd, u32 frb, bool rc)
-	{
-		const double b = CPU.FPR[frb];
-		u32 value;
-		if (b > (double)0x7fffffff)
-		{
-			value = 0x7fffffff;
-			CPU.SetFPSCRException(FPSCR_VXCVI);
-			CPU.FPSCR.FI = 0;
-			CPU.FPSCR.FR = 0;
-		}
-		else if (b < -(double)0x80000000)
-		{
-			value = 0x80000000;
-			CPU.SetFPSCRException(FPSCR_VXCVI);
-			CPU.FPSCR.FI = 0;
-			CPU.FPSCR.FR = 0;
-		}
-		else
-		{
-			s32 i = (s32)b;
-			double di = i;
-			if (di == b)
-			{
-				CPU.SetFPSCR_FI(0);
-				CPU.FPSCR.FR = 0;
-			}
-			else
-			{
-				CPU.SetFPSCR_FI(1);
-				CPU.FPSCR.FR = fabs(di) > fabs(b);
-			}
-			value = (u32)i;
-		}
-
-		(u64&)CPU.FPR[frd] = (u64)value;
-		if(rc) CPU.UpdateCR1();
-	}
-	void FDIV(u32 frd, u32 fra, u32 frb, bool rc)
+	void FCTIWZ(u32 frd, u32 frb, bool rc) {FCTIW(frd, frb, rc, true);}
+	void FDIV(u32 frd, u32 fra, u32 frb, bool rc) {FDIV(frd, fra, frb, rc, false);}
+	void FDIV(u32 frd, u32 fra, u32 frb, bool rc, bool single)
 	{
 		double res;
 
@@ -3937,25 +3822,35 @@ private:
 			}
 		}
 
-		CPU.FPR[frd] = res;
+		if(single) CPU.FPR[frd] = (float)res;
+		else       CPU.FPR[frd] = res;
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
-	void FSUB(u32 frd, u32 fra, u32 frb, bool rc)
+	void FSUB(u32 frd, u32 fra, u32 frb, bool rc) {FSUB(frd, fra, frb, rc, false);}
+	void FSUB(u32 frd, u32 fra, u32 frb, bool rc, bool single)
 	{
-		CPU.FPR[frd] = CPU.FPR[fra] - CPU.FPR[frb];
+		const double res = CPU.FPR[fra] - CPU.FPR[frb];
+		if(single) CPU.FPR[frd] = (float)res;
+		else       CPU.FPR[frd] = res;
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
-	void FADD(u32 frd, u32 fra, u32 frb, bool rc)
+	void FADD(u32 frd, u32 fra, u32 frb, bool rc) {FADD(frd, fra, frb, rc, false);}
+	void FADD(u32 frd, u32 fra, u32 frb, bool rc, bool single)
 	{
-		CPU.FPR[frd] = CPU.FPR[fra] + CPU.FPR[frb];
+		const double res = CPU.FPR[fra] + CPU.FPR[frb];
+		if(single) CPU.FPR[frd] = (float)res;
+		else       CPU.FPR[frd] = res;
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
-	void FSQRT(u32 frd, u32 frb, bool rc)
+	void FSQRT(u32 frd, u32 frb, bool rc) {FSQRT(frd, frb, rc, false);}
+	void FSQRT(u32 frd, u32 frb, bool rc, bool single)
 	{
-		CPU.FPR[frd] = sqrt(CPU.FPR[frb]);
+		const double res = sqrt(CPU.FPR[frb]);
+		if(single) CPU.FPR[frd] = (float)res;
+		else       CPU.FPR[frd] = res;
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
@@ -3964,15 +3859,16 @@ private:
 		CPU.FPR[frd] = CPU.FPR[fra] >= 0.0 ? CPU.FPR[frc] : CPU.FPR[frb];
 		if(rc) CPU.UpdateCR1();
 	}
-	void FMUL(u32 frd, u32 fra, u32 frc, bool rc)
+	void FMUL(u32 frd, u32 fra, u32 frc, bool rc) {FMUL(frd, fra, frc, rc, false);}
+	void FMUL(u32 frd, u32 fra, u32 frc, bool rc, bool single)
 	{
+		double res;
 		if((FPRdouble::IsINF(CPU.FPR[fra]) && CPU.FPR[frc] == 0.0) || (FPRdouble::IsINF(CPU.FPR[frc]) && CPU.FPR[fra] == 0.0))
 		{
 			CPU.SetFPSCRException(FPSCR_VXIMZ);
-			CPU.FPR[frd] = FPR_NAN;
+			res = FPR_NAN;
 			CPU.FPSCR.FI = 0;
 			CPU.FPSCR.FR = 0;
-			CPU.FPSCR.FPRF = FPR_QNAN;
 		}
 		else
 		{
@@ -3981,10 +3877,12 @@ private:
 				CPU.SetFPSCRException(FPSCR_VXSNAN);
 			}
 
-			CPU.FPR[frd] = CPU.FPR[fra] * CPU.FPR[frc];
-			CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
+			res = CPU.FPR[fra] * CPU.FPR[frc];
 		}
 
+		if(single) CPU.FPR[frd] = (float)res;
+		else       CPU.FPR[frd] = res;
+		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
 	void FRSQRTE(u32 frd, u32 frb, bool rc)
@@ -3996,30 +3894,21 @@ private:
 		CPU.FPR[frd] = 1.0 / sqrt(CPU.FPR[frb]);
 		if(rc) CPU.UpdateCR1();
 	}
-	void FMSUB(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
+	void FMSUB(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, false, true, false);}
+	void FMADD(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, false, false, false);}
+	void FMADD(u32 frd, u32 fra, u32 frc, u32 frb, bool rc, bool neg, bool sub, bool single)
 	{
-		CPU.FPR[frd] = CPU.FPR[fra] * CPU.FPR[frc] - CPU.FPR[frb];
+		const double a = CPU.FPR[fra];
+		const double b = CPU.FPR[frb];
+		const double c = CPU.FPR[frc];
+		const double res = a * c + (sub ? -b : b);
+		if(single) CPU.FPR[frd] = (float)(neg ? -res : res);
+		else       CPU.FPR[frd] = (neg ? -res : res);
 		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
 		if(rc) CPU.UpdateCR1();
 	}
-	void FMADD(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = CPU.FPR[fra] * CPU.FPR[frc] + CPU.FPR[frb];
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FNMSUB(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = -(CPU.FPR[fra] * CPU.FPR[frc] - CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
-	void FNMADD(u32 frd, u32 fra, u32 frc, u32 frb, bool rc)
-	{
-		CPU.FPR[frd] = -(CPU.FPR[fra] * CPU.FPR[frc] + CPU.FPR[frb]);
-		CPU.FPSCR.FPRF = CPU.FPR[frd].GetType();
-		if(rc) CPU.UpdateCR1();
-	}
+	void FNMSUB(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, true, true, false);}
+	void FNMADD(u32 frd, u32 fra, u32 frc, u32 frb, bool rc) {FMADD(frd, fra, frc, frb, rc, true, false, false);}
 	void FCMPO(u32 crfd, u32 fra, u32 frb)
 	{
 		int cmp_res = FPRdouble::Cmp(CPU.FPR[fra], CPU.FPR[frb]);
@@ -4062,7 +3951,8 @@ private:
 		CPU.FPR[frd] = fabs(CPU.FPR[frb]);
 		if(rc) CPU.UpdateCR1();
 	}
-	void FCTID(u32 frd, u32 frb, bool rc)
+	void FCTID(u32 frd, u32 frb, bool rc) {FCTID(frd, frb, rc, false);}
+	void FCTID(u32 frd, u32 frb, bool rc, bool truncate)
 	{
 		const double b = CPU.FPR[frb];
 		u64 r;
@@ -4083,7 +3973,8 @@ private:
 		else
 		{
 			s64 i = 0;
-			switch(CPU.FPSCR.RN)
+			const u32 rn = truncate ? FPSCR_RN_ZERO : CPU.FPSCR.RN;
+			switch(rn)
 			{
 			case FPSCR_RN_NEAR:
 				{
@@ -4121,44 +4012,7 @@ private:
 		(u64&)CPU.FPR[frd] = r;
 		if(rc) CPU.UpdateCR1();
 	}
-	void FCTIDZ(u32 frd, u32 frb, bool rc)
-	{
-		const double b = CPU.FPR[frb];
-		u64 r;
-		if(b > (double)0x7fffffffffffffff)
-		{
-			r = 0x7fffffffffffffff;
-			CPU.SetFPSCRException(FPSCR_VXCVI);
-			CPU.FPSCR.FI = 0;
-			CPU.FPSCR.FR = 0;
-		}
-		else if (b < -(double)0x8000000000000000)
-		{
-			r = 0x8000000000000000;
-			CPU.SetFPSCRException(FPSCR_VXCVI);
-			CPU.FPSCR.FI = 0;
-			CPU.FPSCR.FR = 0;
-		}
-		else
-		{
-			s64 i = (s64)b;
-			double di = (double)i;
-			if (di == b)
-			{
-				CPU.SetFPSCR_FI(0);
-				CPU.FPSCR.FR = 0;
-			}
-			else
-			{
-				CPU.SetFPSCR_FI(1);
-				CPU.FPSCR.FR = fabs(di) > fabs(b);
-			}
-			r = (u64)i;
-		}
-
-		(u64&)CPU.FPR[frd] = r;
-		if(rc) CPU.UpdateCR1();
-	}
+	void FCTIDZ(u32 frd, u32 frb, bool rc) {FCTID(frd, frb, rc, true);}
 	void FCFID(u32 frd, u32 frb, bool rc)
 	{
 		s64 bi = (s64&)CPU.FPR[frb];

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -247,8 +247,8 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -256,7 +256,7 @@ private:
 			else if (std::isinf(a) && std::isinf(b) && a != b)
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
-				CPU.VPR[vd]._f[w] = a + b;
+				CPU.VPR[vd]._f[w] = CheckVSCR_NJ(a + b);
 		}
 	}
 	void VADDSBS(u32 vd, u32 va, u32 vb) //nf
@@ -465,11 +465,11 @@ private:
 		{
 			u32 mask = 1<<31 | 1<<30;
 
-			const float A = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
-			const float B = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 
-			if (A <=  B) mask &= ~(1 << 31);
-			if (A >= -B) mask &= ~(1 << 30);
+			if (a <=  b) mask &= ~(1 << 31);
+			if (a >= -b) mask &= ~(1 << 30);
 
 			CPU.VPR[vd]._u32[w] = mask;
 
@@ -768,7 +768,7 @@ private:
 
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 			{
 				CPU.VPR[vd]._s32[w] = 0;
@@ -797,7 +797,7 @@ private:
 
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 			{
 				CPU.VPR[vd]._s32[w] = 0;
@@ -828,11 +828,11 @@ private:
 		// and between different executions on the same implementation.
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
-				CPU.VPR[vd]._f[w] = powf(2.0f, b);
+				CPU.VPR[vd]._f[w] = CheckVSCR_NJ(powf(2.0f, b));
 		}
 	}
 	void VLOGEFP(u32 vd, u32 vb)
@@ -841,20 +841,20 @@ private:
 		// and between different executions on the same implementation.
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
-				CPU.VPR[vd]._f[w] = log2f(b);
+				CPU.VPR[vd]._f[w] = log2f(b);  // Can never be denormal.
 		}
 	}
 	void VMADDFP(u32 vd, u32 va, u32 vc, u32 vb)
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
-			const float c = CPU.VPR[vc]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
+			const float c = CheckVSCR_NJ(CPU.VPR[vc]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -865,9 +865,11 @@ private:
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
 			{
-				CPU.VPR[vd]._f[w] = fmaf(a, c, b);
-				if (std::isnan(CPU.VPR[vd]._f[w]))
+				const float result = fmaf(a, c, b);
+				if (std::isnan(result))
 					CPU.VPR[vd]._f[w] = (float)FPR_NAN;
+				else
+					CPU.VPR[vd]._f[w] = CheckVSCR_NJ(result);
 			}
 		}
 	}
@@ -875,8 +877,8 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -975,8 +977,8 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -1275,9 +1277,9 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
-			const float c = CPU.VPR[vc]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
+			const float c = CheckVSCR_NJ(CPU.VPR[vc]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -1288,9 +1290,11 @@ private:
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
 			{
-				CPU.VPR[vd]._f[w] = -fmaf(a, c, -b);
-				if (std::isnan(CPU.VPR[vd]._f[w]))
+				const float result = -fmaf(a, c, -b);
+				if (std::isnan(result))
 					CPU.VPR[vd]._f[w] = (float)FPR_NAN;
+				else
+					CPU.VPR[vd]._f[w] = CheckVSCR_NJ(result);
 			}
 		}
 	}
@@ -1566,18 +1570,18 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
-				CPU.VPR[vd]._f[w] = 1.0f / b;
+				CPU.VPR[vd]._f[w] = CheckVSCR_NJ(1.0f / b);
 		}
 	}
 	void VRFIM(u32 vd, u32 vb)
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
@@ -1588,7 +1592,7 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
@@ -1599,7 +1603,7 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
@@ -1610,7 +1614,7 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else
@@ -1645,13 +1649,13 @@ private:
 		for (uint w = 0; w < 4; w++)
 		{
 			//TODO: accurate div
-			const float b = CPU.VPR[vb]._f[w];
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
 			else if (b < 0)
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
-				CPU.VPR[vd]._f[w] = 1.0f / sqrtf(b);
+				CPU.VPR[vd]._f[w] = 1.0f / sqrtf(b);  // Can never be denormal.
 		}
 	}
 	void VSEL(u32 vd, u32 va, u32 vb, u32 vc)
@@ -1844,8 +1848,8 @@ private:
 	{
 		for (uint w = 0; w < 4; w++)
 		{
-			const float a = CPU.VPR[va]._f[w];
-			const float b = CPU.VPR[vb]._f[w];
+			const float a = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
+			const float b = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 			if (std::isnan(a))
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
@@ -1853,7 +1857,7 @@ private:
 			else if (std::isinf(a) && std::isinf(b) && a == b)
 				CPU.VPR[vd]._f[w] = (float)FPR_NAN;
 			else
-				CPU.VPR[vd]._f[w] = a - b;
+				CPU.VPR[vd]._f[w] = CheckVSCR_NJ(a - b);
 		}
 	}
 	void VSUBSBS(u32 vd, u32 va, u32 vb) //nf

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -144,14 +144,8 @@ private:
 		case 0x001: return CPU.XER.XER;
 		case 0x008: return CPU.LR;
 		case 0x009: return CPU.CTR;
-		case 0x100: 
-		case 0x101:
-		case 0x102:
-		case 0x103:
-		case 0x104:
-		case 0x105:
-		case 0x106:
-		case 0x107: return CPU.USPRG[n - 0x100];
+		case 0x100: return CPU.VRSAVE;
+		case 0x103: return CPU.SPRG[3];
 
 		case 0x10C: CPU.TB = get_time(); return CPU.TB;
 		case 0x10D: CPU.TB = get_time(); return CPU.TBH;
@@ -178,14 +172,8 @@ private:
 		case 0x001: CPU.XER.XER = value; return;
 		case 0x008: CPU.LR = value; return;
 		case 0x009: CPU.CTR = value; return;
-		case 0x100: 
-		case 0x101:
-		case 0x102:
-		case 0x103:
-		case 0x104:
-		case 0x105:
-		case 0x106:
-		case 0x107: CPU.USPRG[n - 0x100] = value; return;
+		case 0x100: CPU.VRSAVE = (u32)value; return;
+		case 0x103: throw fmt::Format("WriteSPR(0x103, 0x%llx): Write to read-only SPR", value);
 
 		case 0x10C: throw fmt::Format("WriteSPR(0x10C, 0x%llx): Write to time-based SPR", value);
 		case 0x10D: throw fmt::Format("WriteSPR(0x10D, 0x%llx): Write to time-based SPR", value);

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -1930,15 +1930,14 @@ private:
 	}
 	void VSUMSWS(u32 vd, u32 va, u32 vb)
 	{
-		CPU.VPR[vd].clear();
-			
-		s64 sum = CPU.VPR[vb]._s32[3];
+		s64 sum = CPU.VPR[vb]._s32[0];
 
 		for (uint w = 0; w < 4; w++)
 		{
 			sum += CPU.VPR[va]._s32[w];
 		}
 
+		CPU.VPR[vd].clear();
 		if (sum > INT32_MAX)
 		{
 			CPU.VPR[vd]._s32[0] = (s32)INT32_MAX;

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -148,7 +148,7 @@ private:
 		case 0x103: return CPU.SPRG[3];
 
 		case 0x10C: CPU.TB = get_time(); return CPU.TB;
-		case 0x10D: CPU.TB = get_time(); return CPU.TBH;
+		case 0x10D: CPU.TB = get_time(); return CPU.TB >> 32;
 
 		case 0x110:
 		case 0x111:
@@ -2884,7 +2884,7 @@ private:
 		switch(n)
 		{
 		case 0x10C: CPU.GPR[rd] = CPU.TB; break;
-		case 0x10D: CPU.GPR[rd] = CPU.TBH; break;
+		case 0x10D: CPU.GPR[rd] = CPU.TB >> 32; break;
 		default: throw fmt::Format("mftb r%d, %d", rd, spr);
 		}
 	}

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3059,7 +3059,16 @@ private:
 	void LFSX(u32 frd, u32 ra, u32 rb)
 	{
 		const u64 addr = ra ? CPU.GPR[ra] + CPU.GPR[rb] : CPU.GPR[rb];
-		CPU.FPR[frd] = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		float val = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		if (!FPRdouble::IsNaN(val))
+		{
+			CPU.FPR[frd] = val;
+		}
+		else
+		{
+			u64 bits = (u32&)val;
+			(u64&)CPU.FPR[frd] = (bits & 0x80000000) << 32 | 7ULL << 60 | (bits & 0x7fffffff) << 29;
+		}
 	}
 	void SRW(u32 ra, u32 rs, u32 rb, bool rc)
 	{
@@ -3120,7 +3129,16 @@ private:
 	void LFSUX(u32 frd, u32 ra, u32 rb)
 	{
 		const u64 addr = CPU.GPR[ra] + CPU.GPR[rb];
-		CPU.FPR[frd] = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		float val = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		if (!FPRdouble::IsNaN(val))
+		{
+			CPU.FPR[frd] = val;
+		}
+		else
+		{
+			u64 bits = (u32&)val;
+			(u64&)CPU.FPR[frd] = (bits & 0x80000000) << 32 | 7ULL << 60 | (bits & 0x7fffffff) << 29;
+		}
 		CPU.GPR[ra] = addr;
 	}
 	void SYNC(u32 l)
@@ -3176,7 +3194,17 @@ private:
 	void STFSX(u32 frs, u32 ra, u32 rb)
 	{
 		const u64 addr = ra ? CPU.GPR[ra] + CPU.GPR[rb] : CPU.GPR[rb];
-		vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)CPU.FPR[frs];
+		double val = CPU.FPR[frs];
+		if (!FPRdouble::IsNaN(val))
+		{
+			vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)val;
+		}
+		else
+		{
+			u64 bits = (u64&)val;
+			u32 bits32 = (bits>>32 & 0x80000000) | (bits>>29 & 0x7fffffff);
+			vm::get_ref<be_t<u32>>(vm::cast(addr)) = (float)bits32;
+		}
 	}
 	void STVRX(u32 vs, u32 ra, u32 rb)
 	{
@@ -3188,7 +3216,17 @@ private:
 	void STFSUX(u32 frs, u32 ra, u32 rb)
 	{
 		const u64 addr = CPU.GPR[ra] + CPU.GPR[rb];
-		vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)CPU.FPR[frs];
+		double val = CPU.FPR[frs];
+		if (!FPRdouble::IsNaN(val))
+		{
+			vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)val;
+		}
+		else
+		{
+			u64 bits = (u64&)val;
+			u32 bits32 = (bits>>32 & 0x80000000) | (bits>>29 & 0x7fffffff);
+			vm::get_ref<be_t<u32>>(vm::cast(addr)) = (float)bits32;
+		}
 		CPU.GPR[ra] = addr;
 	}
 	void STSWI(u32 rd, u32 ra, u32 nb)
@@ -3459,12 +3497,30 @@ private:
 	void LFS(u32 frd, u32 ra, s32 d)
 	{
 		const u64 addr = ra ? CPU.GPR[ra] + d : d;
-		CPU.FPR[frd] = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		float val = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		if (!FPRdouble::IsNaN(val))
+		{
+			CPU.FPR[frd] = val;
+		}
+		else
+		{
+			u64 bits = (u32&)val;
+			(u64&)CPU.FPR[frd] = (bits & 0x80000000) << 32 | 7ULL << 60 | (bits & 0x7fffffff) << 29;
+		}
 	}
 	void LFSU(u32 frd, u32 ra, s32 ds)
 	{
 		const u64 addr = CPU.GPR[ra] + ds;
-		CPU.FPR[frd] = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		float val = vm::get_ref<be_t<float>>(vm::cast(addr)).value();
+		if (!FPRdouble::IsNaN(val))
+		{
+			CPU.FPR[frd] = val;
+		}
+		else
+		{
+			u64 bits = (u32&)val;
+			(u64&)CPU.FPR[frd] = (bits & 0x80000000) << 32 | 7ULL << 60 | (bits & 0x7fffffff) << 29;
+		}
 		CPU.GPR[ra] = addr;
 	}
 	void LFD(u32 frd, u32 ra, s32 d)
@@ -3481,12 +3537,32 @@ private:
 	void STFS(u32 frs, u32 ra, s32 d)
 	{
 		const u64 addr = ra ? CPU.GPR[ra] + d : d;
-		vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)CPU.FPR[frs];
+		double val = CPU.FPR[frs];
+		if (!FPRdouble::IsNaN(val))
+		{
+			vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)val;
+		}
+		else
+		{
+			u64 bits = (u64&)val;
+			u32 bits32 = (bits>>32 & 0x80000000) | (bits>>29 & 0x7fffffff);
+			vm::get_ref<be_t<u32>>(vm::cast(addr)) = (float)bits32;
+		}
 	}
 	void STFSU(u32 frs, u32 ra, s32 d)
 	{
 		const u64 addr = CPU.GPR[ra] + d;
-		vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)CPU.FPR[frs];
+		double val = CPU.FPR[frs];
+		if (!FPRdouble::IsNaN(val))
+		{
+			vm::get_ref<be_t<float>>(vm::cast(addr)) = (float)val;
+		}
+		else
+		{
+			u64 bits = (u64&)val;
+			u32 bits32 = (bits>>32 & 0x80000000) | (bits>>29 & 0x7fffffff);
+			vm::get_ref<be_t<u32>>(vm::cast(addr)) = (float)bits32;
+		}
 		CPU.GPR[ra] = addr;
 	}
 	void STFD(u32 frs, u32 ra, s32 d)

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -2693,7 +2693,7 @@ private:
 			{
 				if(crm & (1 << i))
 				{
-					CPU.SetCR(7 - i, CPU.GPR[rs] & (0xf << (i * 4)));
+					CPU.SetCR(7 - i, (CPU.GPR[rs] >> (i * 4)) & 0xf);
 				}
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -3956,7 +3956,7 @@ private:
 	{
 		const double b = CPU.FPR[frb];
 		u64 r;
-		if(b > (double)0x7fffffffffffffff)
+		if(b >= (double)0x8000000000000000)
 		{
 			r = 0x7fffffffffffffff;
 			CPU.SetFPSCRException(FPSCR_VXCVI);

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -463,13 +463,13 @@ private:
 
 		for (uint w = 0; w < 4; w++)
 		{
-			u32 mask = 0;
+			u32 mask = 1<<31 | 1<<30;
 
 			const float A = CheckVSCR_NJ(CPU.VPR[va]._f[w]);
 			const float B = CheckVSCR_NJ(CPU.VPR[vb]._f[w]);
 
-			if (A >  B) mask |= 1 << 31;
-			if (A < -B) mask |= 1 << 30;
+			if (A <=  B) mask &= ~(1 << 31);
+			if (A >= -B) mask &= ~(1 << 30);
 
 			CPU.VPR[vd]._u32[w] = mask;
 
@@ -881,8 +881,14 @@ private:
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
+			else if (a > b)
+				CPU.VPR[vd]._f[w] = a;
+			else if (b > a)
+				CPU.VPR[vd]._f[w] = b;
+			else if (CPU.VPR[vb]._u32[w] == 0x80000000)
+				CPU.VPR[vd]._f[w] = a;  // max(+0,-0) = +0
 			else
-				CPU.VPR[vd]._f[w] = std::max(a, b);
+				CPU.VPR[vd]._f[w] = b;
 		}
 	}
 	void VMAXSB(u32 vd, u32 va, u32 vb) //nf
@@ -975,8 +981,14 @@ private:
 				CPU.VPR[vd]._f[w] = SilenceNaN(a);
 			else if (std::isnan(b))
 				CPU.VPR[vd]._f[w] = SilenceNaN(b);
+			else if (a < b)
+				CPU.VPR[vd]._f[w] = a;
+			else if (b < a)
+				CPU.VPR[vd]._f[w] = b;
+			else if (CPU.VPR[vb]._u32[w] == 0x00000000)
+				CPU.VPR[vd]._f[w] = a;  // min(-0,+0) = -0
 			else
-				CPU.VPR[vd]._f[w] = std::min(a, b);
+				CPU.VPR[vd]._f[w] = b;
 		}
 	}
 	void VMINSB(u32 vd, u32 va, u32 vb) //nf

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -3746,6 +3746,16 @@ void Compiler::STVLX(u32 vs, u32 ra, u32 rb) {
                               addr_i8_ptr, vs_i8_ptr, size_i64, m_ir_builder->getInt32(1), m_ir_builder->getInt1(false));
 }
 
+void Compiler::STDBRX(u32 rs, u32 ra, u32 rb) {
+    auto addr_i64 = GetGpr(rb);
+    if (ra) {
+        auto ra_i64 = GetGpr(ra);
+        addr_i64    = m_ir_builder->CreateAdd(ra_i64, addr_i64);
+    }
+
+    WriteMemory(addr_i64, GetGpr(rs), 0, false);
+}
+
 void Compiler::STSWX(u32 rs, u32 ra, u32 rb) {
     CompilationError("STSWX");
 }

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -3311,7 +3311,7 @@ void Compiler::MFSPR(u32 rd, u32 spr) {
         rd_i64 = GetCtr();
         break;
     case 0x100:
-        rd_i64 = GetUsprg0();
+        rd_i64 = GetVrsave();
         break;
     case 0x10C:
         rd_i64 = Call<u64>("get_time", get_time);
@@ -3503,7 +3503,7 @@ void Compiler::MTSPR(u32 spr, u32 rs) {
         SetCtr(rs_i64);
         break;
     case 0x100:
-        SetUsprg0(rs_i64);
+        SetVrsave(rs_i64);
         break;
     default:
         assert(0);
@@ -5278,17 +5278,19 @@ void Compiler::SetXerSo(Value * so) {
     SetXer(xer_i64);
 }
 
-Value * Compiler::GetUsprg0() {
-    auto usrpg0_i8_ptr  = m_ir_builder->CreateConstGEP1_32(m_state.args[CompileTaskState::Args::State], (unsigned int)offsetof(PPUThread, USPRG));
-    auto usprg0_i64_ptr = m_ir_builder->CreateBitCast(usrpg0_i8_ptr, m_ir_builder->getInt64Ty()->getPointerTo());
-    return m_ir_builder->CreateAlignedLoad(usprg0_i64_ptr, 8);
+Value * Compiler::GetVrsave() {
+    auto vrsave_i8_ptr  = m_ir_builder->CreateConstGEP1_32(m_state.args[CompileTaskState::Args::State], (unsigned int)offsetof(PPUThread, VRSAVE));
+    auto vrsave_i32_ptr = m_ir_builder->CreateBitCast(vrsave_i8_ptr, m_ir_builder->getInt32Ty()->getPointerTo());
+    auto val_i32        = m_ir_builder->CreateAlignedLoad(vrsave_i32_ptr, 4);
+    return m_ir_builder->CreateZExtOrTrunc(val_i32, m_ir_builder->getInt64Ty());
 }
 
-void Compiler::SetUsprg0(Value * val_x64) {
+void Compiler::SetVrsave(Value * val_x64) {
     auto val_i64        = m_ir_builder->CreateBitCast(val_x64, m_ir_builder->getInt64Ty());
-    auto usprg0_i8_ptr  = m_ir_builder->CreateConstGEP1_32(m_state.args[CompileTaskState::Args::State], (unsigned int)offsetof(PPUThread, USPRG));
-    auto usprg0_i64_ptr = m_ir_builder->CreateBitCast(usprg0_i8_ptr, m_ir_builder->getInt64Ty()->getPointerTo());
-    m_ir_builder->CreateAlignedStore(val_i64, usprg0_i64_ptr, 8);
+    auto val_i32        = m_ir_builder->CreateZExtOrTrunc(val_i64, m_ir_builder->getInt32Ty());
+    auto vrsave_i8_ptr  = m_ir_builder->CreateConstGEP1_32(m_state.args[CompileTaskState::Args::State], (unsigned int)offsetof(PPUThread, VRSAVE));
+    auto vrsave_i32_ptr = m_ir_builder->CreateBitCast(vrsave_i8_ptr, m_ir_builder->getInt32Ty()->getPointerTo());
+    m_ir_builder->CreateAlignedStore(val_i32, vrsave_i32_ptr, 8);
 }
 
 Value * Compiler::GetFpscr() {

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -598,6 +598,7 @@ namespace ppu_recompiler_llvm {
         void LFDX(u32 frd, u32 ra, u32 rb) override;
         void LFDUX(u32 frd, u32 ra, u32 rb) override;
         void STVLX(u32 vs, u32 ra, u32 rb) override;
+        void STDBRX(u32 rd, u32 ra, u32 rb) override;
         void STSWX(u32 rs, u32 ra, u32 rb) override;
         void STWBRX(u32 rs, u32 ra, u32 rb) override;
         void STFSX(u32 frs, u32 ra, u32 rb) override;

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -860,11 +860,11 @@ namespace ppu_recompiler_llvm {
         /// Set the SO bit of XER
         void SetXerSo(llvm::Value * so);
 
-        /// Get USPRG0
-        llvm::Value * GetUsprg0();
+        /// Get VRSAVE
+        llvm::Value * GetVrsave();
 
-        /// Set USPRG0
-        void SetUsprg0(llvm::Value * val_x64);
+        /// Set VRSAVE
+        void SetVrsave(llvm::Value * val_x64);
 
         /// Load FPSCR
         llvm::Value * GetFpscr();

--- a/rpcs3/Emu/Cell/PPUOpcodes.h
+++ b/rpcs3/Emu/Cell/PPUOpcodes.h
@@ -344,6 +344,8 @@ namespace PPU_opcodes
 		DIVD   = 0x1e9,
 		DIVW   = 0x1eb,
 		LVLX   = 0x207, //Load Vector Left Indexed
+		SUBFCO = 0x208,
+		ADDCO  = 0x20a,
 		LDBRX  = 0x214,
 		LSWX   = 0x215,
 		LWBRX  = 0x216,
@@ -351,21 +353,33 @@ namespace PPU_opcodes
 		SRW    = 0x218,
 		SRD    = 0x21b,
 		LVRX   = 0x227, //Load Vector Right Indexed
+		SUBFO  = 0x228,
 		LFSUX  = 0x237,
 		LSWI   = 0x255,
 		SYNC   = 0x256,
 		LFDX   = 0x257,
+		NEGO   = 0x268,
 		LFDUX  = 0x277,
 		STVLX  = 0x287, //Store Vector Left Indexed
+		SUBFEO = 0x288,
+		ADDEO  = 0x28a,
+		STDBRX = 0x294,
 		STSWX  = 0x295,
 		STWBRX = 0x296,
 		STFSX  = 0x297,
 		STVRX  = 0x2a7, //Store Vector Right Indexed
 		STFSUX = 0x2b7,
+		SUBFZEO= 0x2c8,
+		ADDZEO = 0x2ca,
 		STSWI  = 0x2d5,
 		STFDX  = 0x2d7, //Store Floating-Point Double Indexed
+		SUBFMEO= 0x2e8,
+		MULLDO = 0x2e9,
+		ADDMEO = 0x2ea,
+		MULLWO = 0x2eb,
 		STFDUX = 0x2f7,
 		LVLXL  = 0x307, //Load Vector Left Indexed Last
+		ADDO   = 0x30a,
 		LHBRX  = 0x316,
 		SRAW   = 0x318,
 		SRAD   = 0x31a,
@@ -380,9 +394,13 @@ namespace PPU_opcodes
 		EXTSH  = 0x39a,
 		STVRXL = 0x3a7, //Store Vector Right Indexed Last
 		EXTSB  = 0x3ba,
+		DIVDUO = 0x3c9,
+		DIVWUO = 0x3cb,
 		STFIWX = 0x3d7,
 		EXTSW  = 0x3da,
 		ICBI   = 0x3d6, //Instruction Cache Block Invalidate
+		DIVDO  = 0x3e9,
+		DIVWO  = 0x3eb,
 		DCBZ   = 0x3f6, //Data Cache Block Set to Zero
 	};
 
@@ -759,6 +777,7 @@ public:
 	virtual void LFDX(u32 frd, u32 ra, u32 rb) = 0;
 	virtual void LFDUX(u32 frd, u32 ra, u32 rb) = 0;
 	virtual void STVLX(u32 vs, u32 ra, u32 rb) = 0;
+	virtual void STDBRX(u32 rs, u32 ra, u32 rb) = 0;
 	virtual void STSWX(u32 rs, u32 ra, u32 rb) = 0;
 	virtual void STWBRX(u32 rs, u32 ra, u32 rb) = 0;
 	virtual void STFSX(u32 frs, u32 ra, u32 rb) = 0;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -43,7 +43,6 @@ void PPUThread::DoReset()
 	memset(FPR,  0, sizeof(FPR));
 	memset(GPR,  0, sizeof(GPR));
 	memset(SPRG, 0, sizeof(SPRG));
-	memset(USPRG, 0, sizeof(USPRG));
 
 	CR.CR       = 0;
 	LR          = 0;
@@ -52,6 +51,7 @@ void PPUThread::DoReset()
 	XER.XER     = 0;
 	FPSCR.FPSCR = 0;
 	VSCR.VSCR   = 0;
+        VRSAVE      = 0;
 
 	cycle = 0;
 }

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -443,18 +443,22 @@ struct PPCdouble
 
 	PPCdouble() : _u64(0)
 	{
+		type = UpdateType();
 	}
 
 	PPCdouble(double val) : _double(val)
 	{
+		type = UpdateType();
 	}
 
 	PPCdouble(u64 val) : _u64(val)
 	{
+		type = UpdateType();
 	}
 
 	PPCdouble(u32 val) : _u64(val)
 	{
+		type = UpdateType();
 	}
 };
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -531,7 +531,8 @@ public:
 	u64 LR;     //SPR 0x008 : Link Register
 	u64 CTR;    //SPR 0x009 : Count Register
 
-	u64 USPRG[8];	//SPR 0x100 - 0x107: User-SPR General-Purpose Registers
+	u32 VRSAVE; //SPR 0x100: VR Save/Restore Register (32 bits)
+
 	u64 SPRG[8]; //SPR 0x110 - 0x117 : SPR General-Purpose Registers
 
 	//TBR : Time-Base Registers

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -702,6 +702,8 @@ public:
 	{
 		if ((FPSCR.FPSCR & mask) != mask) FPSCR.FX = 1;
 		FPSCR.FPSCR |= mask;
+		UpdateFPSCR_VX();
+		UpdateFPSCR_FEX();
 	}
 
 	void SetFPSCR_FI(const u32 val)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -53,6 +53,8 @@ enum FPSCR_EXP
 	FPSCR_VXSOFT    = 0x00000400,
 	FPSCR_VXSQRT    = 0x00000200,
 	FPSCR_VXCVI     = 0x00000100,
+
+	FPSCR_VX_ALL    = FPSCR_VXSNAN | FPSCR_VXISI | FPSCR_VXIDI | FPSCR_VXZDZ | FPSCR_VXIMZ | FPSCR_VXVC | FPSCR_VXSOFT | FPSCR_VXSQRT | FPSCR_VXCVI,
 };
 
 enum FPSCR_RN
@@ -675,6 +677,25 @@ public:
 	{
 		XER.OV = set;
 		XER.SO |= set;
+	}
+
+	void UpdateFPSCR_FEX()
+	{
+		const u32 exceptions = (FPSCR.FPSCR >> 25) & 0x1F;
+		const u32 enabled = (FPSCR.FPSCR >> 3) & 0x1F;
+		if (exceptions & enabled) FPSCR.FEX = 1;
+	}
+
+	void UpdateFPSCR_VX()
+	{
+		if (FPSCR.FPSCR & FPSCR_VX_ALL) FPSCR.VX = 1;
+	}
+
+	void SetFPSCR(const u32 val)
+	{
+		FPSCR.FPSCR = val & ~(FPSCR_FEX | FPSCR_VX);
+		UpdateFPSCR_VX();
+		UpdateFPSCR_FEX();
 	}
 
 	void SetFPSCRException(const FPSCR_EXP mask)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -652,7 +652,7 @@ public:
 		UpdateCRn<T>(0, val, 0);
 	}
 
-	template<typename T> void UpdateCR1()
+	void UpdateCR1()
 	{
 		SetCR_LT(1, FPSCR.FX);
 		SetCR_GT(1, FPSCR.FEX);
@@ -669,6 +669,12 @@ public:
 
 	bool IsCarry(const u64 a, const u64 b) { return (a + b) < a; }
 	bool IsCarry(const u64 a, const u64 b, const u64 c) { return IsCarry(a, b) || IsCarry(a + b, c); }
+
+	void SetOV(const bool set)
+	{
+		XER.OV = set;
+		XER.SO |= set;
+	}
 
 	void SetFPSCRException(const FPSCR_EXP mask)
 	{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -542,16 +542,7 @@ public:
 	u64 SPRG[8]; //SPR 0x110 - 0x117 : SPR General-Purpose Registers
 
 	//TBR : Time-Base Registers
-	union
-	{
-		u64 TB;	//TBR 0x10C - 0x10D
-
-		struct
-		{
-			u32 TBH;
-			u32 TBL;
-		};
-	};
+	u64 TB;	//TBR 0x10C - 0x10D
 
 	u64 cycle;
 


### PR DESCRIPTION
These patches add all missing user-mode instructions to the PPU instruction decoder and interpreter, and fix various bugs in the existing instruction implementations. With these changes, the PPU interpreter passes all but 27 tests from http://achurch.org/cell-test/ppu.s (which has been validated against a real PS3); the failing tests require either floating-point inexact result detection or support for different floating-point rounding modes.