### PR TITLE
Fix some small mistakes

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -157,7 +157,7 @@ std::string fmt::detail::format(const char* fmt, size_t len)
 
 extern const std::string fmt::placeholder = "???";
 
-std::string replace_first(const std::string& src, const std::string& from, const std::string& to)
+std::string fmt::replace_first(const std::string& src, const std::string& from, const std::string& to)
 {
 	auto pos = src.find(from);
 
@@ -169,11 +169,12 @@ std::string replace_first(const std::string& src, const std::string& from, const
 	return (pos ? src.substr(0, pos) + to : to) + std::string(src.c_str() + pos + from.length());
 }
 
-std::string replace_all(std::string src, const std::string& from, const std::string& to)
+std::string fmt::replace_all(const std::string &src, const std::string& from, const std::string& to)
 {
-	for (auto pos = src.find(from); pos != std::string::npos; src.find(from, pos + 1))
+	std::string target = src;
+	for (auto pos = target.find(from); pos != std::string::npos; pos = target.find(from, pos + 1))
 	{
-		src = (pos ? src.substr(0, pos) + to : to) + std::string(src.c_str() + pos + from.length());
+		target = (pos ? target.substr(0, pos) + to : to) + std::string(target.c_str() + pos + from.length());
 		pos += to.length();
 	}
 

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -123,7 +123,7 @@ namespace fmt
 	}
 
 	std::string replace_first(const std::string& src, const std::string& from, const std::string& to);
-	std::string replace_all(std::string src, const std::string& from, const std::string& to);
+	std::string replace_all(const std::string &src, const std::string& from, const std::string& to);
 
 	template<size_t list_size>
 	std::string replace_all(std::string src, const std::pair<std::string, std::string>(&list)[list_size])

--- a/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
@@ -1004,6 +1004,7 @@ s32 cellGcmUnmapIoAddress(u64 io)
 	{
 		u64 ea;
 		io = io >> 20;
+		size = size >> 20;
 		ea = offsetTable.eaAddress[io];
 
 		for (u32 i = 0; i<size; i++)

--- a/rpcs3/Emu/SysCalls/lv2/cellFs.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/cellFs.cpp
@@ -235,11 +235,17 @@ s32 cellFsStat(vm::ptr<const char> path, vm::ptr<CellFsStat> sb)
 
 	Emu.GetVFS().GetDevice(_path, real_path);
 
+	int stat_result;
+#ifdef _WIN32
+	struct _stat64 buf;
+	stat_result = _stat64(real_path.c_str(), &buf);
+#elif
 	struct stat buf;
-
-	if (int result = stat(real_path.c_str(), &buf))
+	stat_result = stat(real_path.c_str(), &buf);
+#endif
+	if (stat_result)
 	{
-		sys_fs->Error("cellFsStat(): stat('%s') failed -> 0x%x", real_path.c_str(), result);
+		sys_fs->Error("cellFsStat(): stat('%s') failed -> 0x%x", real_path.c_str(), stat_result);
 	}
 	else
 	{


### PR DESCRIPTION
* replace_first and replace_all were in the wrong namespace, so they could not be linked
* replace_all did not work correctly (would loop indefinately)
* cellGcmUnmapIoAddress did not shif the size, so it would run past the end of the mmap array
* fsstat did use a 32-bit size on Windows, so files >4 gigs would return "stat failed"