### PR TITLE
re-enable threadlist in GUI

### DIFF
--- a/rpcs3/Emu/CPU/CPUThreadManager.h
+++ b/rpcs3/Emu/CPU/CPUThreadManager.h
@@ -18,7 +18,7 @@ public:
 	CPUThread& AddThread(CPUThreadType type);
 	void RemoveThread(const u32 id);
 
-	//std::vector<std::shared_ptr<CPUThread>>& GetThreads() { return m_threads; }
+	std::vector<std::shared_ptr<CPUThread>> GetThreads() { return m_threads; }
 	s32 GetThreadNumById(CPUThreadType type, u32 id);
 	std::shared_ptr<CPUThread> GetThread(u32 id);
 	std::shared_ptr<CPUThread> GetThread(u32 id, CPUThreadType type);

--- a/rpcs3/Gui/InterpreterDisAsm.cpp
+++ b/rpcs3/Gui/InterpreterDisAsm.cpp
@@ -108,12 +108,12 @@ void InterpreterDisAsmFrame::UpdateUnitList()
 {
 	m_choice_units->Freeze();
 	m_choice_units->Clear();
-	//auto& thrs = Emu.GetCPU().GetThreads();
+	auto thrs = Emu.GetCPU().GetThreads();
 
-	//for (auto& t : thrs)
-	//{
-	//	m_choice_units->Append(t->GetFName(), t.get());
-	//}
+	for (auto& t : thrs)
+	{
+		m_choice_units->Append(t->GetFName(), t.get());
+	}
 
 	m_choice_units->Thaw();
 }


### PR DESCRIPTION
This used to crash so it was removed. However I think this is a cruicial feature.
This is the only way to observe the stack-frames, registers and disasm around the PC
in a user friendly way.

The reason this caused crashes was that we got a reference to a std::vector and iterated
over it in one thread while another thread could modify it (and thereby invalidating the
iterators). The way I "fixed" it is to just copy the `std::vector<std::shared_ptr<...>>`
and iterate over the copy. This obviously has some overhead (locking the shared_ptr
counters and incrementing them). It also allows entities other than the Thread manager
to keep the Thread objects frome being deleted but that should not be a problem.