### PR TITLE
About ppu thread stacksize

### DIFF
--- a/rpcs3/Emu/SysCalls/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/sys_ppu_thread.cpp
@@ -162,6 +162,15 @@ PPUThread* ppu_thread_create(u32 entry, u64 arg, s32 prio, u32 stacksize, bool i
 {
 	PPUThread& new_thread = *(PPUThread*)&Emu.GetCPU().AddThread(CPU_THREAD_PPU);
 
+	// Note: I haven't figured out the minimum stack size of PPU Thread.
+	//       Maybe it can be done with pthread_attr_getstacksize function.
+	//       And i toke 4096 (PTHREAD_STACK_MIN, and the smallest allocation unit) for this.
+	if ((stacksize % 4096) || (stacksize == 0)) {
+		// If not times of smallest allocation unit, round it up to the nearest one.
+		// And regard zero as a same condition.
+		stacksize = 4096 * ((u32)(stacksize / 4096) + 1);
+	}
+
 	u32 id = new_thread.GetId();
 	new_thread.SetEntry(entry);
 	new_thread.SetPrio(prio);

--- a/rpcs3/Emu/SysCalls/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/sys_ppu_thread.cpp
@@ -162,12 +162,14 @@ PPUThread* ppu_thread_create(u32 entry, u64 arg, s32 prio, u32 stacksize, bool i
 {
 	PPUThread& new_thread = *(PPUThread*)&Emu.GetCPU().AddThread(CPU_THREAD_PPU);
 
-	// Note: I haven't figured out the minimum stack size of PPU Thread.
+	// Note: (Syphurith) I haven't figured out the minimum stack size of PPU Thread.
 	//       Maybe it can be done with pthread_attr_getstacksize function.
 	//       And i toke 4096 (PTHREAD_STACK_MIN, and the smallest allocation unit) for this.
 	if ((stacksize % 4096) || (stacksize == 0)) {
 		// If not times of smallest allocation unit, round it up to the nearest one.
 		// And regard zero as a same condition.
+		sys_ppu_thread.Warning("sys_ppu_thread_create: stacksize increased from 0x%x to 0x%x.",
+			stacksize, 4096 * ((u32)(stacksize / 4096) + 1));
 		stacksize = 4096 * ((u32)(stacksize / 4096) + 1);
 	}
 


### PR DESCRIPTION
I saw someone experience the issue of Assertion failed at `m_stack_size` in PPUThread.cpp which may be caused by the initial stack size or even the implementation of `sys_ppu_thread_create`. So i made it to round the requested size up to product of 4KB, even it was told to allocate 0B.
For the detailed issue and a test LLVM build of it, see [Here](http://www.emunewz.net/forum/showthread.php?tid=167481&pid=219885#pid219885). Hope this can solve the stack size problem.
*Note: If you want to test something, please take the file in the post and get the test.*